### PR TITLE
Fix problem to fetch the custom avatar

### DIFF
--- a/workflow/src/stash/stash_facade.py
+++ b/workflow/src/stash/stash_facade.py
@@ -51,7 +51,12 @@ class StashFacade(object):
         response = self._get(self._stash_url('/users/{}'.format(user_slug.lower())), params={'avatarSize': 64}).json()
         if 'avatarUrl' not in response:
             return None
-        response = self._get(response['avatarUrl'], params={}, stream=True)
+
+        if response['avatarUrl'].startswith(('https://', 'http://')):
+            response = self._get(response['avatarUrl'], params={}, stream=True)
+        else:
+            response = self._get('{}/{}'.format(self._base_url, response['avatarUrl']), params={}, stream=True)
+
         response.raw.decode_content = True
         return response.raw
 


### PR DESCRIPTION
When using custom icon in Stash, the error is occured.


```
01:45:53 workflow.py:2158 ERROR    Invalid URL '/users/jane/avatar.png?s=64': No schema supplied. Perhaps you meant http:///users/jane/avatar.png?s=64?
Traceback (most recent call last):
  File "src/lib/workflow/workflow.py", line 2151, in run
    func(self)
  File "/Users/f440/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.CCA398BA-DC57-43A4-B2FC-49AEC5E57BD2/src/sync.py", line 111, in main
    _fetch_stash_data_if_necessary(stash_facade)
  File "/Users/f440/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.CCA398BA-DC57-43A4-B2FC-49AEC5E57BD2/src/sync.py", line 81, in _fetch_stash_data_if_necessary
    repos = workflow().cached_data(REPOS_CACHE_KEY, wrapper_repositories, max_age=UPDATE_INTERVAL_REPOS)
  File "src/lib/workflow/workflow.py", line 1784, in cached_data
    data = data_func()
  File "/Users/f440/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.CCA398BA-DC57-43A4-B2FC-49AEC5E57BD2/src/sync.py", line 79, in wrapper_repositories
    return _find_all_repositories(stash_facade)
  File "/Users/f440/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.CCA398BA-DC57-43A4-B2FC-49AEC5E57BD2/src/sync.py", line 38, in _find_all_repositories
    _fetch_user_avatars(repositories, stash_facade)
  File "/Users/f440/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.CCA398BA-DC57-43A4-B2FC-49AEC5E57BD2/src/sync.py", line 47, in _fetch_user_avatars
    avatar = stash_facade.fetch_user_avatar(r.project_key[1:])
  File "src/stash/stash_facade.py", line 54, in fetch_user_avatar
    response = self._get(response['avatarUrl'], params={}, stream=True)
  File "src/stash/stash_facade.py", line 91, in _get
    response = requests.get(url, params=params, **options)
  File "src/lib/requests/api.py", line 69, in get
    return request('get', url, params=params, **kwargs)
  File "src/lib/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "src/lib/requests/sessions.py", line 451, in request
    prep = self.prepare_request(req)
  File "src/lib/requests/sessions.py", line 382, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "src/lib/requests/models.py", line 304, in prepare
    self.prepare_url(url, params)
  File "src/lib/requests/models.py", line 362, in prepare_url
    to_native_string(url, 'utf8')))
MissingSchema: Invalid URL '/users/jane/avatar.png?s=64': No schema supplied. Perhaps you meant http:///users/jane/avatar.png?s=64?
```

`avatarUrl` is possible to set either only path part (e.g. /users/NAME/avatar.png?s=64) or full part of URL (= Gravatar's URL).

This PR is fix it.